### PR TITLE
Use display trait for schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "ccdexplorer-schema-parser"
-version = "0.1.10"
+version = "0.1.14"
 dependencies = [
  "concordium-contracts-common",
  "concordium-smart-contract-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccdexplorer-schema-parser"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ fn get_schema(versioned_module_schema: Vec<u8>) -> PyResult<VersionedModuleSchem
 fn extract_schema_template_ffi(versioned_module_schema: Vec<u8>) -> PyResult<String> {
     let schema = get_schema(versioned_module_schema)?;
 
-    Ok(schema.to_string())
+    Ok(format!("{}", schema))
 }
 
 #[pyfunction]


### PR DESCRIPTION
Using the display trait for the schema. This aligns the display of the schema across the block explorers.